### PR TITLE
No post processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bin
+xtend-gen

--- a/cbbdemo.ide/META-INF/MANIFEST.MF
+++ b/cbbdemo.ide/META-INF/MANIFEST.MF
@@ -7,8 +7,8 @@ Bundle-SymbolicName: cbbdemo.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: cbbdemo,
  org.eclipse.xtext.ide,
- org.eclipse.xtext.xbase.ide,
- org.antlr.runtime
+ org.antlr.runtime,
+ org.eclipse.xtext.xbase.lib
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.ericsson.toside.ide.contentassist.antlr.internal,
  com.ericsson.toside.ide.contentassist.antlr

--- a/cbbdemo.tests/META-INF/MANIFEST.MF
+++ b/cbbdemo.tests/META-INF/MANIFEST.MF
@@ -8,8 +8,8 @@ Bundle-ActivationPolicy: lazy
 Require-Bundle: cbbdemo,
  org.junit;bundle-version="4.12.0",
  org.eclipse.xtext.testing,
- org.eclipse.xtext.xbase.testing,
- org.eclipse.xtext.xbase.lib
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtext.xbase.testing
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: com.ericsson.toside.tests;x-internal=true
 Import-Package: org.hamcrest.core,

--- a/cbbdemo/META-INF/MANIFEST.MF
+++ b/cbbdemo/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-SymbolicName: cbbdemo; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,
- org.eclipse.xtext.xbase,
  org.eclipse.equinox.common;bundle-version="3.5.0",
  org.eclipse.emf.ecore,
  org.eclipse.xtext.xbase.lib,

--- a/cbbdemo/plugin.xml
+++ b/cbbdemo/plugin.xml
@@ -4,7 +4,7 @@
 	<extension point="org.eclipse.emf.ecore.generated_package">
 		<package 
 			uri = "http://www.ericsson.com/toside/CBBdemo"
-			class = "com.ericsson.toside.cbbdemo.CBBdemoPackage"
+			class = "com.ericsson.toside.cbbdemo.CbbdemoPackage"
 			genModel = "model/generated/CBBdemo.genmodel" />
 	</extension>
 </plugin>

--- a/cbbdemo/src/com/ericsson/toside/CBBdemoRuntimeModule.xtend
+++ b/cbbdemo/src/com/ericsson/toside/CBBdemoRuntimeModule.xtend
@@ -3,9 +3,23 @@
  */
 package com.ericsson.toside
 
+import org.eclipse.xtext.generator.IFilePostProcessor
+import org.eclipse.emf.common.util.URI
 
 /**
  * Use this class to register components to be used at runtime / without the Equinox extension registry.
  */
 class CBBdemoRuntimeModule extends AbstractCBBdemoRuntimeModule {
+	
+	def Class<? extends IFilePostProcessor> bindIFilePostProcessor() {
+		return NoOpPostProcessor;
+	}
+	
+	static class NoOpPostProcessor implements IFilePostProcessor {
+		
+		override postProcess(URI fileURI, CharSequence content) {
+			content
+		}
+		
+	}
 }


### PR DESCRIPTION
I disabled the default post processor, which was turning the generator tree into a string and therefore disabled generation of trace files. With the change you will see trace files next to the generated c code.